### PR TITLE
App exits when back button pressed

### DIFF
--- a/cordova/BiteTracker/www/js/index.js
+++ b/cordova/BiteTracker/www/js/index.js
@@ -11,7 +11,10 @@ var app = {
     // 'pause', 'resume', etc.
     onDeviceReady: function() {
       window.open = cordova.InAppBrowser.open
-        cordova.InAppBrowser.open('http://bitetracker.herokuapp.com', '_self', 'location=no,zoom=no');
+      var inAppBrowser = cordova.InAppBrowser.open('http://bitetracker.herokuapp.com', '_self', 'location=no,zoom=no');
+      inAppBrowser.addEventListener("exit", function(){
+        navigator.app.exitApp();
+      })
     },
 
     // Update DOM on a Received Event


### PR DESCRIPTION
Current flow:
Android app -> static loading screen -> inAppBrowser (handling webapp)

Now, when back button pressed in inAppBrowser, it goes back to static loading screen
Because of the default android behaviour, back button goes back, when you are in a root context of android app, you quit the app, I decided to handle the returning switch from inAppBrowser to static loading screen and set the event to quit the app.
Hope you agree with me.